### PR TITLE
TERMINUS_ENV => MULTIDEV

### DIFF
--- a/.circleci/auto-update.sh
+++ b/.circleci/auto-update.sh
@@ -116,7 +116,7 @@ fi
 if [[ ${CMS_FRAMEWORK} == "drupal" ]]
 then
 
-    PLUGIN_UPDATES=$(terminus drush ${SITE_UUID}.${TERMINUS_ENV} -- pm-updatestatus --format=list --check-disabled | grep -v ok)
+    PLUGIN_UPDATES=$(terminus drush ${SITE_UUID}.${MULTIDEV} -- pm-updatestatus --format=list --check-disabled | grep -v ok)
 
     echo $PLUGIN_UPDATES
 


### PR DESCRIPTION
TERMINUS_ENV produces: 
```
[error]  The environment argument must be given as <site_name>.<environment> 
```

Use MULTIDEV instead